### PR TITLE
fix: ensure server uri placeholder and default value parity

### DIFF
--- a/src/components/Sidebar/SettingsModal/Index.svelte
+++ b/src/components/Sidebar/SettingsModal/Index.svelte
@@ -1,7 +1,7 @@
 <script>
   import QuickPinSettings from "./QuickPinSettings.svelte"
 
-  import connectApi, { STATUS } from "stores/api.svelte"
+  import connectApi, { STATUS, SERVER_URI_PLACEHOLDER } from "stores/api.svelte"
   const api = connectApi()
 
   let configModal = $state()
@@ -106,7 +106,7 @@
                 <input
                   type="text"
                   class="grow"
-                  placeholder="localhost:8188"
+                  placeholder={SERVER_URI_PLACEHOLDER}
                   bind:value={api.uri}
                 />
               </label>

--- a/src/stores/api.svelte.js
+++ b/src/stores/api.svelte.js
@@ -17,13 +17,15 @@ export const STATUS = {
   ERROR: "ERROR",
 }
 
+export const SERVER_URI_PLACEHOLDER = "localhost:8188"
+
 import localStore from "lib/localStore"
 
 const SERVER_URI_KEY = "extraUI.stores.apiConnectionManager.serverUri"
 const IGNORELIST_KEY = "extraUI.stores.apiConnectionManager.ignorelist"
 const AUTOCONNECT_KEY = "extraUI.stores.apiConnectionManager.autoconnect"
 
-const localServerUri = localStore(SERVER_URI_KEY, null)
+const localServerUri = localStore(SERVER_URI_KEY, SERVER_URI_PLACEHOLDER)
 const localIgnorelist = localStore(IGNORELIST_KEY, [])
 const localAutoconnect = localStore(AUTOCONNECT_KEY, null)
 


### PR DESCRIPTION
i know you said no PR in readme 😿 but
spent some time hitting head on table before i realised default value is null
this should define the default server uri somewhere and make sure its sets in ui (as placeholder) and local storage